### PR TITLE
list-tables operation via roundtrip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "nektar"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,12 +9,11 @@ use thrift::transport::{
 };
 
 use crate::cmds::catalogs::GetCatalogs;
-use crate::cmds::tables::DropTable;
 use crate::cmds::{
     catalogs::{CreateCatalog, GetCatalog},
     databases::GetDatabases,
     partitions::{GetPartitionNamesByParts, GetPartitions},
-    tables::{CreateTable, GetTable},
+    tables::{CreateTable, DropTable, GetTable, ListTables},
 };
 
 use crate::error::CliError;
@@ -56,6 +55,7 @@ pub enum Commands {
     GetDatabases(GetDatabases),
     CreateCatalog(CreateCatalog),
     CreateTable(CreateTable),
+    ListTables(ListTables),
     DropTable(DropTable),
 }
 
@@ -98,6 +98,7 @@ impl Cli {
             Commands::CreateTable(create_table) => {
                 serialize(self.format, create_table.run(client)?)
             }
+            Commands::ListTables(list_tables) => serialize(self.format, list_tables.run(client)?),
             Commands::DropTable(drop_table) => serialize(self.format, drop_table.run(client)?),
         }
     }

--- a/src/cmds/tables.rs
+++ b/src/cmds/tables.rs
@@ -83,7 +83,8 @@ impl RunCommand<()> for DropTable {
 #[derive(Debug, Args)]
 pub struct ListTables {
     db_name: String,
-    #[arg(short, long, default_value = "*")]
+    /// An optional glob search by table name
+    #[arg(short = 's', long = "search", default_value = "*")]
     name_glob: String,
 }
 

--- a/src/cmds/tables.rs
+++ b/src/cmds/tables.rs
@@ -78,3 +78,19 @@ impl RunCommand<()> for DropTable {
         }
     }
 }
+
+/// Get tables in database with optional glob on name
+#[derive(Debug, Args)]
+pub struct ListTables {
+    db_name: String,
+    #[arg(short, long, default_value = "*")]
+    name_glob: String,
+}
+
+impl RunCommand<Vec<Table>> for ListTables {
+    fn run(self, mut client: MetastoreClient) -> Result<Vec<Table>, CliError> {
+        Ok(client
+            .get_tables(self.db_name.to_owned(), self.name_glob.to_owned())
+            .and_then(|tables| client.get_table_objects_by_name(self.db_name.to_owned(), tables))?)
+    }
+}


### PR DESCRIPTION
* implements a list tables operation by roundtripping the `get_tables` -> `get_table_objects_by_name` thrift methods
  * gives a UX that provides glob-based table search in a database:

```
# list all tables in default database
nektar list-tables 

# list all tables in default namespace starting with foo
nektar list-tables -s 'foo*'
```