### PR TITLE
Unnest inner error before serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "nektar"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "assert_cmd",
  "clap",


### PR DESCRIPTION
Unpack `Result` before returning output
